### PR TITLE
Testing for all items endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+testing
+- all_items endpoint
+  - happy path testing includes:
+    - default params are page = 1 and per_page = 20
+    - optional params work properly individually
+    - optional params work properly in conjunction with each other
+  - Edge case testing includes:
+    - the endpoint returns everything if the per_page is grater the the available data
+    - the endpoint returns a page with no objects if the page number is greater then available pages
+    - it returns all remaining items if the last page is not equal to the per_page limit
+  - Sad Path testing includes:
+    - endpoint returns page 1 if page query param is less then 1
+    - endpoint returns 20 items per page if per_page query param is less then 1
+    - endpoint uses the default params for page and per_page if the query param is empty

--- a/app/facades/items_facade.rb
+++ b/app/facades/items_facade.rb
@@ -1,10 +1,15 @@
 class ItemsFacade
 
   def self.all_items(per_page, page)
-    page = 1 unless page
-    per_page = 20 unless per_page
+    page = 1 unless valid_param?(page)
+    per_page = 20 unless valid_param?(per_page)
     offset = ((page.to_i - 1) * per_page.to_i)
 
     Item.offset(offset).limit(per_page)
+  end
+
+  def self.valid_param?(param)
+    return true if (param && param !="") && param.to_i >= 1
+    false
   end
 end

--- a/spec/requests/all_items_spec.rb
+++ b/spec/requests/all_items_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe "all items API end point", type: :request do
       expect(json[:data].last[:id].to_i).to eq(@items[per_page - 1].id)
     end
 
+    it "returns 20 items per page if quary param for per_page is less then 1" do
+      per_page = -1
+      page = 1
+      get "/api/v1/items?per_page=#{per_page}&page=#{page}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(20)
+      expect(json[:data].first[:id].to_i).to eq(@items.first.id)
+      expect(json[:data].last[:id].to_i).to eq(@items[19].id)
+    end
+
     it "returns the default if quary params are blank" do
       get "/api/v1/items?per_page=&page="
 

--- a/spec/requests/all_items_spec.rb
+++ b/spec/requests/all_items_spec.rb
@@ -1,24 +1,104 @@
 require 'rails_helper'
 
-RSpec.describe "all items API end point" do
+RSpec.describe "all items API end point", type: :request do
   before :each do
-    create_list(:item, 100)
+    @items = create_list(:item, 100)
   end
 
-  it "returens items equal to the per_page value" do
-    per_page = 10
-    get "/api/v1/items?per_page=#{per_page}"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+  describe "Happy Path" do
+    it "returens items equal to the per_page value" do
+      per_page = 10
+      get "/api/v1/items?per_page=#{per_page}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].count).to eq(per_page)
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(per_page)
+      expect(json[:data].first[:id].to_i).to eq(@items.first.id)
+      expect(json[:data].last[:id].to_i).to eq(@items[per_page - 1].id)
+    end
+
+    it "returens 20 items by default" do
+      get "/api/v1/items"
+      parsed = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(200)
+      expect(parsed[:data].count).to eq(20)
+      expect(json[:data].first[:id].to_i).to eq(@items.first.id)
+      expect(json[:data].last[:id].to_i).to eq(@items[19].id)
+    end
+
+    it "returens the next 20 items if page 2 is requested" do
+      page = 2
+      get "/api/v1/items?page=#{page}"
+      parsed = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(200)
+      expect(parsed[:data].count).to eq(20)
+      expect(json[:data].first[:id].to_i).to eq(@items[20].id)
+      expect(json[:data].last[:id].to_i).to eq(@items[39].id)
+    end
+
+    it "returens the next 10 items if page 2 & 10 items_per_page is requested" do
+      per_page = 10
+      page = 2
+      get "/api/v1/items?per_page=10&page=#{page}"
+      parsed = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(200)
+      expect(parsed[:data].count).to eq(10)
+      expect(json[:data].first[:id].to_i).to eq(@items[10].id)
+      expect(json[:data].last[:id].to_i).to eq(@items[19].id)
+    end
   end
 
-  it "returens 20 items by default" do
-    get "/api/v1/items"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+  describe "Edge Cases" do
+    it "returns all items if per page is larger then the number of items" do
+      per_page = 200
+      get "/api/v1/items?per_page=#{per_page}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].count).to eq(20)
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(100)
+    end
+
+    it "returns all remaing items if page_count is the last page" do
+      per_page = 30
+      page = 4
+      get "/api/v1/items?per_page=#{per_page}&page=#{page}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(10)
+      expect(json[:data].first[:id].to_i).to eq(@items[90].id)
+      expect(json[:data].last[:id].to_i).to eq(@items[99].id)
+    end
+
+    it "returns an no objects if page count is too high" do
+      per_page = 125
+      page = 2
+      get "/api/v1/items?per_page=#{per_page}&page=#{page}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(0)
+    end
+  end
+
+  describe "Sad Path" do
+    it "returns page 1 if quary param for page is less then 1" do
+      per_page = 10
+      page = -1
+      get "/api/v1/items?per_page=#{per_page}&page=#{page}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(per_page)
+      expect(json[:data].first[:id].to_i).to eq(@items.first.id)
+      expect(json[:data].last[:id].to_i).to eq(@items[per_page - 1].id)
+    end
+
+    it "returns the default if quary params are blank" do
+      get "/api/v1/items?per_page=&page="
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(20)
+      expect(json[:data].first[:id].to_i).to eq(@items.first.id)
+      expect(json[:data].last[:id].to_i).to eq(@items[19].id)
+    end
   end
 end

--- a/spec/requests/unshipped_order_revenue_spec.rb
+++ b/spec/requests/unshipped_order_revenue_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe "Unshiped Revenue", type: :request do
     get "/api/v1/revenue/unshipped"
 
     expect(response.status).to eq(200)
-    expect(json[:data].count).to eq(10)
+    expect(json[:data].count).to eq(4)
   end
 end


### PR DESCRIPTION
- all_items endpoint
  - happy path testing includes:
    - default params are page = 1 and per_page = 20
    - optional params work properly individually
    - optional params work properly in conjunction with each other
  - Edge case testing includes:
    - the endpoint returns everything if the per_page is grater the the available data
    - the endpoint returns a page with no objects if the page number is greater then available pages
    - it returns all remaining items if the last page is not equal to the per_page limit
  - Sad Path testing includes:
    - endpoint returns page 1 if page query param is less then 1
    - endpoint returns 20 items per page if per_page query param is less then 1
    - endpoint uses the default params for page and per_page if the query param is empty