### PR TITLE
Testing for find item endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ testing
     - endpoint returns page 1 if page query param is less then 1
     - endpoint returns 20 items per page if per_page query param is less then 1
     - endpoint uses the default params for page and per_page if the query param is empty
+
+- find_item (search) endpoint
+  - happy path testing includes:
+    - the endpoint returns the first item with a matching name sorted alphabetically (when the name query param is used)
+    - the endpoint returns no object if there are no matches for the item name (when the name query param is used)
+    - the endpoint returns the first item above or below the minimum or maximum value sorted alphabetically (when only one price query param is used)
+    - the endpoint returns the first item between the maximum and minimum values sorted alphabetically (if both price query params are used)
+  - Edge case testing includes:
+    - the endpoint returns no item if the minimum value is greater then all items
+    - the endpoint returns no item if the maximum value is less then all items
+    - the endpoint returns no item if the maximum value is less then the minimum value
+  - Sad path testing includes:
+    - the endpoint returns a 400 response if both a name and price query param are give
+    - the endpoint returns a 400 response if min max price query params are less then 0

--- a/spec/requests/all_items_spec.rb
+++ b/spec/requests/all_items_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "all items API end point", type: :request do
   end
 
   describe "Sad Path" do
-    it "returns page 1 if quary param for page is less then 1" do
+    it "returns page 1 if query param for page is less then 1" do
       per_page = 10
       page = -1
       get "/api/v1/items?per_page=#{per_page}&page=#{page}"
@@ -92,7 +92,7 @@ RSpec.describe "all items API end point", type: :request do
       expect(json[:data].last[:id].to_i).to eq(@items[per_page - 1].id)
     end
 
-    it "returns 20 items per page if quary param for per_page is less then 1" do
+    it "returns 20 items per page if query param for per_page is less then 1" do
       per_page = -1
       page = 1
       get "/api/v1/items?per_page=#{per_page}&page=#{page}"
@@ -103,7 +103,7 @@ RSpec.describe "all items API end point", type: :request do
       expect(json[:data].last[:id].to_i).to eq(@items[19].id)
     end
 
-    it "returns the default if quary params are blank" do
+    it "returns the default if query params are blank" do
       get "/api/v1/items?per_page=&page="
 
       expect(response.status).to eq(200)

--- a/spec/requests/all_items_spec.rb
+++ b/spec/requests/all_items_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "all items API end point", type: :request do
     it "returens the next 10 items if page 2 & 10 items_per_page is requested" do
       per_page = 10
       page = 2
-      get "/api/v1/items?per_page=10&page=#{page}"
+      get "/api/v1/items?per_page=#{per_page}&page=#{page}"
       parsed = JSON.parse(response.body, symbolize_names: true)
 
       expect(response.status).to eq(200)

--- a/spec/requests/all_merchants_spec.rb
+++ b/spec/requests/all_merchants_spec.rb
@@ -1,29 +1,3 @@
-# require 'rails_helper'
-#
-# RSpec.describe "all merchants API end point" do
-#   before :each do
-#     # ActiveRecord::Base.connection.reset_pk_sequence!('merchants')
-#       create_list(:merchant, 100)
-#   end
-#
-#   it "returens merchants equal to the per_page value" do
-#     per_page = 10
-#     get "/api/v1/merchants?per_page=#{per_page}"
-#     parsed = JSON.parse(response.body, symbolize_names: true)
-#
-#     expect(response.status).to eq(200)
-#     expect(parsed[:data].count).to eq(per_page)
-#   end
-#
-#   it "returens 20 merchants by default" do
-#     get "/api/v1/merchants"
-#     parsed = JSON.parse(response.body, symbolize_names: true)
-#
-#     expect(response.status).to eq(200)
-#     expect(parsed[:data].count).to eq(20)
-#   end
-# end
-
 require 'rails_helper'
 
 RSpec.describe "all merchants API end point", type: :request do
@@ -66,7 +40,7 @@ RSpec.describe "all merchants API end point", type: :request do
     it "returens the next 10 merchants if page 2 & 10 merchants_per_page is requested" do
       per_page = 10
       page = 2
-      get "/api/v1/merchants?per_page=10&page=#{page}"
+      get "/api/v1/merchants?per_page=#{per_page}&page=#{page}"
       parsed = JSON.parse(response.body, symbolize_names: true)
 
       expect(response.status).to eq(200)

--- a/spec/requests/all_merchants_spec.rb
+++ b/spec/requests/all_merchants_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "all merchants API end point", type: :request do
   end
 
   describe "Sad Path" do
-    it "returns page 1 if quary param for page is less then 1" do
+    it "returns page 1 if query param for page is less then 1" do
       per_page = 10
       page = -1
       get "/api/v1/merchants?per_page=#{per_page}&page=#{page}"
@@ -92,7 +92,7 @@ RSpec.describe "all merchants API end point", type: :request do
       expect(json[:data].last[:id].to_i).to eq(@merchants[per_page - 1].id)
     end
 
-    it "returns 20 merchants per page if quary param for per_page is less then 1" do
+    it "returns 20 merchants per page if query param for per_page is less then 1" do
       per_page = -1
       page = 1
       get "/api/v1/merchants?per_page=#{per_page}&page=#{page}"
@@ -103,7 +103,7 @@ RSpec.describe "all merchants API end point", type: :request do
       expect(json[:data].last[:id].to_i).to eq(@merchants[19].id)
     end
 
-    it "returns the default if quary params are blank" do
+    it "returns the default if query params are blank" do
       get "/api/v1/merchants?per_page=&page="
 
       expect(response.status).to eq(200)

--- a/spec/requests/item_search_spec.rb
+++ b/spec/requests/item_search_spec.rb
@@ -81,10 +81,24 @@ RSpec.describe "item find_one API end point", type: :request do
       end
     end
     describe "Sad Path" do
-      it "return a400 response if both a name and price query param are give" do
+      it "returns a 400 response if both a name and price query param are give" do
         max = 1000.50
         name = "name"
         get "/api/v1/items/find?max_price=#{max}&name=#{name}"
+
+        expect(response.status).to eq(400)
+      end
+
+      it "returns a 400 response if the max price query param is less then 0" do
+        max = -1
+        get "/api/v1/items/find?max_price=#{max}"
+
+        expect(response.status).to eq(400)
+      end
+
+      it "returns a 400 response if the min price query param is less then 0" do
+        min = -1
+        get "/api/v1/items/find?min_price=#{min}"
 
         expect(response.status).to eq(400)
       end

--- a/spec/requests/item_search_spec.rb
+++ b/spec/requests/item_search_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "item find_one API end point" do
+RSpec.describe "item find_one API end point", type: :request do
   before :each do
     create(:item, name: "item", unit_price: 1000.99)
     create(:item, name: "thing", unit_price: 10.99)
@@ -10,48 +10,84 @@ RSpec.describe "item find_one API end point" do
     create(:item, name: "item-that-does things", unit_price: 100.99)
   end
 
-  it "returns one item with a matching name" do
-    name = "things"
-    get "/api/v1/items/find?name=#{name}"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+  describe "Happy Path" do
+    describe "Search by name" do
+      it "returns the first item with a matching name sorted alphabetically" do
+        name = "things"
+        get "/api/v1/items/find?name=#{name}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].keys).to eq([:id, :type, :attributes])
-  end
+        expect(response.status).to eq(200)
+        expect(json[:data][:attributes][:name]).to eq("item-that-does things")
+      end
 
-  it "returns one item based on a minimum value" do
-    price = "1"
-    get "/api/v1/items/find?min_price=#{price}"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+      it "returns no object if there are no matches for the item name" do
+        name = "No Match"
+        get "/api/v1/items/find?name=#{name}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].keys).to eq([:id, :type, :attributes])
-  end
+        expect(response.status).to eq(200)
+        expect(json[:data].count).to eq(0)
+      end
+    end
 
-  it "returns one item based on a maximum value" do
-    price = "1000.50"
-    get "/api/v1/items/find?max_price=#{price}"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+    describe "Search by price" do
+      it "returns the first item above the minimum value sorted alphabetically" do
+        min = 1
+        get "/api/v1/items/find?min_price=#{min}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].keys).to eq([:id, :type, :attributes])
-  end
+        expect(response.status).to eq(200)
+        expect(json[:data][:attributes][:name]).to eq("another item")
+      end
 
-  it "returns one item when both a min and max value are given" do
-    min = "100.50"
-    max = "1000.50"
-    get "/api/v1/items/find?max_price=#{max}&min_price=#{min}"
-    parsed = JSON.parse(response.body, symbolize_names: true)
+      it "returns the first item below the maximum value sorted alphabetically" do
+        max = 1000.50
+        get "/api/v1/items/find?max_price=#{max}"
 
-    expect(response.status).to eq(200)
-    expect(parsed[:data].keys).to eq([:id, :type, :attributes])
-  end
+        expect(response.status).to eq(200)
+        expect(json[:data][:attributes][:name]).to eq("another item")
+      end
 
-  it "return an error if both a name and price range are give" do
-    max = "1000.50"
-    name = "name"
-    get "/api/v1/items/find?max_price=#{max}&name=#{name}"
+      it "returns the first item between the maximum and minimum values sorted alphabetically" do
+        min = 101.50
+        max = 1000.50
+        get "/api/v1/items/find?max_price=#{max}&min_price=#{min}"
 
-    expect(response.status).to eq(400)
+        expect(response.status).to eq(200)
+        expect(json[:data][:attributes][:name]).to eq("stuff-n-things")
+      end
+    end
+
+    describe "Edge Case" do
+      it "returns no item if the minimum value is greater then all items" do
+        min = 10000
+        get "/api/v1/items/find?min_price=#{min}"
+
+        expect(response.status).to eq(200)
+        expect(json[:data].count).to eq(0)
+      end
+      it "returns no item if the maximum value is less then all items" do
+        max = 0.10
+        get "/api/v1/items/find?max_price=#{max}"
+
+        expect(response.status).to eq(200)
+        expect(json[:data].count).to eq(0)
+      end
+      it "returns no item if the maximum value is less then the minimum value" do
+        min = 25
+        max = 10
+        get "/api/v1/items/find?min_price=#{min}&max_price=#{max}"
+
+        expect(response.status).to eq(200)
+        expect(json[:data].count).to eq(0)
+      end
+    end
+    describe "Sad Path" do
+      it "return a400 response if both a name and price query param are give" do
+        max = 1000.50
+        name = "name"
+        get "/api/v1/items/find?max_price=#{max}&name=#{name}"
+
+        expect(response.status).to eq(400)
+      end
+    end
   end
 end


### PR DESCRIPTION
- find_item (search) endpoint
  - happy path testing includes:
    - the endpoint returns the first item with a matching name sorted alphabetically (when the name query param is used)
    - the endpoint returns no object if there are no matches for the item name (when the name query param is used)
    - the endpoint returns the first item above or below the minimum or maximum value sorted alphabetically (when only one price query param is used)
    - the endpoint returns the first item between the maximum and minimum values sorted alphabetically (if both price query params are used)
  - Edge case testing includes:
    - the endpoint returns no item if the minimum value is greater then all items
    - the endpoint returns no item if the maximum value is less then all items
    - the endpoint returns no item if the maximum value is less then the minimum value
  - Sad path testing includes:
    - the endpoint returns a 400 response if both a name and price query param are give
    - the endpoint returns a 400 response if min max price query params are less then 0