### PR TITLE
Testing for merchants by revenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ testing
 
 - merchants_by_revenue endpoint
   - Happy path testing includes:
-    - the endpoint returns the top 5 merchants sorted by revenue as the default
     - the endpoint returns merchants equal to the quantity query params if provided
     - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
   - Edge case testing includes:
     - the endpoint does not includes merchants that do not have any successful transactions
   - Sad path testing includes:
-    - the endpoint uses the default quantity if the quantity query param is less then 1
-    - the endpoint uses the default quantity if the quantity query param is blank
+    - the endpoint returns a 400 response if the quantity query param is less then 1
+    - the endpoint returns a 400 response if the quantity query param is a string
+    - the endpoint returns a 400 response if the quantity query param is blank
+    - the endpoint returns a 400 response if the quantity query param is not provided

--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ application up and running.
 
 Things you may want to cover:
 
-* Ruby version
+this project was built with:
+* Ruby version 2.5.3
+* Rails version 5.2.5
+this project was tested with:
+* RSpec version 3.10
+  - rspec-core 3.10.1
+  - rspec-expectations 3.10.1
+  - rspec-mocks 3.10.2
+  - rspec-rails 5.0.1
+  - rspec-support 3.10.2
+and also makes use of the following note worth gems for testing
+ * Capibara version
+ * FactoryBot version
 
 * System dependencies
 
@@ -56,3 +68,14 @@ testing
   - Happy path testing includes:
     - the endpoint returns all merchants who match the name search params
     - the endpoint returns no objects if no merchants match the name search params
+
+- merchants_by_revenue endpoint
+  - Happy path testing includes:
+    - the endpoint returns the top 5 merchants sorted by revenue as the default
+    - the endpoint returns merchants equal to the quantity query params if provided
+    - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
+  - Edge case testing includes:
+    - the endpoint does not includes merchants that do not have any successful transactions
+  - Sad path testing includes:
+    - the endpoint uses the default quantity if the quantity query param is less then 1
+    - the endpoint uses the default quantity if the quantity query param is blank

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -12,8 +12,12 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def by_revenue
-    merchants = MerchantsFacade.by_revenue(params[:quantity])
-    render json: MerchantNameRevenueSerializer.new(merchants)
+    if MerchantsFacade.valid_param?(params[:quantity])
+      merchants = MerchantsFacade.by_revenue(params[:quantity])
+      render json: MerchantNameRevenueSerializer.new(merchants)
+    else
+      render json: {error: {}}, status: :bad_request
+    end
   end
 
   def by_items
@@ -21,7 +25,7 @@ class Api::V1::MerchantsController < ApplicationController
       merchants = Merchant.merchants_by_items_sold(params[:quantity])
       render json: MerchantNameItemsSerializer.new(merchants)
     else
-      render json: {error: {}}, status: 400
+      render json: {error: {}}, status: :bad_request
     end
   end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def by_revenue
-    merchants = Merchant.merchants_by_revenue(params[:quantity])
+    merchants = MerchantsFacade.by_revenue(params[:quantity])
     render json: MerchantNameRevenueSerializer.new(merchants)
   end
 

--- a/app/facades/merchants_facade.rb
+++ b/app/facades/merchants_facade.rb
@@ -9,7 +9,6 @@ class MerchantsFacade
   end
 
   def self.by_revenue(limit)
-    limit = 5 unless valid_param?(limit)
     Merchant.by_revenue(limit)
   end
 

--- a/app/facades/merchants_facade.rb
+++ b/app/facades/merchants_facade.rb
@@ -8,8 +8,14 @@ class MerchantsFacade
     Merchant.offset(offset).limit(per_page)
   end
 
+  def self.by_revenue(limit)
+    limit = 5 unless valid_param?(limit)
+    Merchant.by_revenue(limit)
+  end
+
   def self.valid_param?(param)
     return true if (param && param !="") && param.to_i >= 1
     false
   end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,7 +5,8 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
 
-  def self.merchants_by_revenue(limit)
+  def self.by_revenue(limit)
+    limit = 5 unless limit
      joins(:transactions)
     .where('transactions.result = ?', 'success')
     .select('merchants.id, merchants.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,7 +6,6 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
 
   def self.by_revenue(limit)
-    limit = 5 unless limit
      joins(:transactions)
     .where('transactions.result = ?', 'success')
     .select('merchants.id, merchants.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')

--- a/spec/requests/merchants_by_revenue_spec.rb
+++ b/spec/requests/merchants_by_revenue_spec.rb
@@ -5,9 +5,64 @@ RSpec.describe "merchants by revenue", type: :request do
     seed_test_db
   end
 
-  it "returnd the top merchants by revenue" do
-    get "/api/v1/revenue/merchants?quantity=15"
+  describe "Happy Path" do
+    it "returns the top 5 merchants sorted by revenue as the default" do
+      get "/api/v1/revenue/merchants"
 
-    expect(response.status).to eq(200)
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(5)
+      expect(json[:data].first[:attributes][:name]).to eq("stand by")
+      expect(json[:data].second[:attributes][:name]).to eq("try again")
+      expect(json[:data].third[:attributes][:name]).to eq("Merchants 4 me")
+      expect(json[:data].fourth[:attributes][:name]).to eq("the merchants for all")
+      expect(json[:data].fifth[:attributes][:name]).to eq("the merchants guild")
+    end
+
+    it "returns merchants equal to the quantity query params sorted by revenue" do
+      qty = 2
+      get "/api/v1/revenue/merchants?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(2)
+      expect(json[:data].first[:attributes][:name]).to eq("stand by")
+      expect(json[:data].second[:attributes][:name]).to eq("try again")
+    end
+
+    it "returns all merchants if the quantity query params is larger then the number of merchants sorted by revenue" do
+      qty = 50
+      get "/api/v1/revenue/merchants?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(6)
+    end
+  end
+
+  describe "Edge Cases" do
+    it "does not includes merchants that do not have any successful transactions" do
+      create(:merchant, name: "No Invoices")
+      qty = 20
+      get "/api/v1/revenue/merchants?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(6)
+      expect(json[:data]).to_not include("No Invoices")
+    end
+  end
+
+  describe "Sad Path" do
+    it "uses the default quantity if the quantity query param is less then 1" do
+      qty = -1
+      get "/api/v1/revenue/merchants?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(5)
+    end
+
+    it "uses the default quantity if the quantity query param is blank" do
+      get "/api/v1/revenue/merchants?quantity="
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(5)
+    end
   end
 end

--- a/spec/requests/merchants_by_revenue_spec.rb
+++ b/spec/requests/merchants_by_revenue_spec.rb
@@ -6,18 +6,6 @@ RSpec.describe "merchants by revenue", type: :request do
   end
 
   describe "Happy Path" do
-    it "returns the top 5 merchants sorted by revenue as the default" do
-      get "/api/v1/revenue/merchants"
-
-      expect(response.status).to eq(200)
-      expect(json[:data].count).to eq(5)
-      expect(json[:data].first[:attributes][:name]).to eq("stand by")
-      expect(json[:data].second[:attributes][:name]).to eq("try again")
-      expect(json[:data].third[:attributes][:name]).to eq("Merchants 4 me")
-      expect(json[:data].fourth[:attributes][:name]).to eq("the merchants for all")
-      expect(json[:data].fifth[:attributes][:name]).to eq("the merchants guild")
-    end
-
     it "returns merchants equal to the quantity query params sorted by revenue" do
       qty = 2
       get "/api/v1/revenue/merchants?quantity=#{qty}"
@@ -50,19 +38,30 @@ RSpec.describe "merchants by revenue", type: :request do
   end
 
   describe "Sad Path" do
-    it "uses the default quantity if the quantity query param is less then 1" do
+    it "returns a 400 response if the quantity query param is less then 1" do
       qty = -1
       get "/api/v1/revenue/merchants?quantity=#{qty}"
 
-      expect(response.status).to eq(200)
-      expect(json[:data].count).to eq(5)
+      expect(response.status).to eq(400)
     end
 
-    it "uses the default quantity if the quantity query param is blank" do
+    it "returns a 400 response if the quantity query param is a string" do
+      qty = "string"
+      get "/api/v1/revenue/merchants?quantity=#{qty}"
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is blank" do
       get "/api/v1/revenue/merchants?quantity="
 
-      expect(response.status).to eq(200)
-      expect(json[:data].count).to eq(5)
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is not provided" do
+      get "/api/v1/revenue/merchants"
+
+      expect(response.status).to eq(400)
     end
   end
 end


### PR DESCRIPTION
- merchants_by_revenue endpoint
  - Happy path testing includes:
    - the endpoint returns merchants equal to the quantity query params if provided
    - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
  - Edge case testing includes:
    - the endpoint does not includes merchants that do not have any successful transactions
  - Sad path testing includes:
    - the endpoint returns a 400 response if the quantity query param is less then 1
    - the endpoint returns a 400 response if the quantity query param is a string
    - the endpoint returns a 400 response if the quantity query param is blank
    - the endpoint returns a 400 response if the quantity query param is not provided