### PR TITLE
Testing for merchants by items sold

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,19 @@ testing
 
 - merchants_by_revenue endpoint
   - Happy path testing includes:
-    - the endpoint returns merchants equal to the quantity query params if provided
+    - the endpoint returns merchants equal to the quantity query params
+    - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
+  - Edge case testing includes:
+    - the endpoint does not includes merchants that do not have any successful transactions
+  - Sad path testing includes:
+    - the endpoint returns a 400 response if the quantity query param is less then 1
+    - the endpoint returns a 400 response if the quantity query param is a string
+    - the endpoint returns a 400 response if the quantity query param is blank
+    - the endpoint returns a 400 response if the quantity query param is not provided
+
+- merchants_by_items_sold endpoint
+  - Happy path testing includes:
+    - the endpoint returns merchants equal to the quantity query params
     - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
   - Edge case testing includes:
     - the endpoint does not includes merchants that do not have any successful transactions

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -21,8 +21,8 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def by_items
-    if params[:quantity]
-      merchants = Merchant.merchants_by_items_sold(params[:quantity])
+    if MerchantsFacade.valid_param?(params[:quantity])
+      merchants = MerchantsFacade.by_items_sold(params[:quantity])
       render json: MerchantNameItemsSerializer.new(merchants)
     else
       render json: {error: {}}, status: :bad_request

--- a/app/facades/merchants_facade.rb
+++ b/app/facades/merchants_facade.rb
@@ -12,6 +12,10 @@ class MerchantsFacade
     Merchant.by_revenue(limit)
   end
 
+  def self.by_items_sold(limit)
+    Merchant.by_items_sold(limit)
+  end
+
   def self.valid_param?(param)
     return true if (param && param !="") && param.to_i >= 1
     false

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -14,7 +14,7 @@ class Merchant < ApplicationRecord
     .limit(limit)
   end
 
-  def self.merchants_by_items_sold(limit = 5)
+  def self.by_items_sold(limit = 5)
      joins(:transactions)
     .where('transactions.result = ?', 'success')
     .select('merchants.id, merchants.name, sum(invoice_items.quantity) AS item_count')

--- a/spec/requests/Merchants_by_items_sold_spec.rb
+++ b/spec/requests/Merchants_by_items_sold_spec.rb
@@ -4,10 +4,69 @@ RSpec.describe "merchants by items sold", type: :request do
   before :each do
     seed_test_db
   end
+  describe "Happy Path" do
+    it "returns merchants equal to the quantity query params" do
+      qty = 2
+      get "/api/v1/merchants/most_items?quantity=#{qty}"
 
-  it "returnd the top merchants by number of items sold" do
-    get "/api/v1/merchants/most_items?quantity=2"
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(qty)
+      expect(json[:data].first[:attributes][:name]).to eq("try again")
+      expect(json[:data].second[:attributes][:name]).to eq("one more")
+    end
 
-    expect(response.status).to eq(200)
+    it "returns all merchants if the quantity query params is larger then the number of merchants" do
+      qty = 15
+      get "/api/v1/merchants/most_items?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(6)
+      expect(json[:data].first[:attributes][:name]).to eq("try again")
+      expect(json[:data].second[:attributes][:name]).to eq("one more")
+      expect(json[:data].third[:attributes][:name]).to eq("stand by")
+      expect(json[:data].fourth[:attributes][:name]).to eq("the merchants guild")
+      expect(json[:data].fifth[:attributes][:name]).to eq("the merchants for all")
+      expect(json[:data].last[:attributes][:name]).to eq("Merchants 4 me")
+    end
+  end
+
+  describe "Edge Cases" do
+    it "does not includes merchants that do not have any successful transactions" do
+      create(:merchant, name: "No Invoices")
+      qty = 20
+      get "/api/v1/merchants/most_items?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(6)
+      expect(json[:data]).to_not include("No Invoices")
+    end
+  end
+
+  describe "Sad Path" do
+    it "returns a 400 response if the quantity query param is less then 1" do
+      qty = -1
+      get "/api/v1/merchants/most_items?quantity=#{qty}"
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is a string" do
+      qty = "string"
+      get "/api/v1/merchants/most_items?quantity=#{qty}"
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is blank" do
+      get "/api/v1/merchants/most_items?quantity="
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is not provided" do
+      get "/api/v1/merchants/most_items"
+
+      expect(response.status).to eq(400)
+    end
   end
 end


### PR DESCRIPTION
- merchants_by_items_sold endpoint
  - Happy path testing includes:
    - the endpoint returns merchants equal to the quantity query params
    - the endpoint returns all merchants if the quantity query params is larger then the number of merchants
  - Edge case testing includes:
    - the endpoint does not includes merchants that do not have any successful transactions
  - Sad path testing includes:
    - the endpoint returns a 400 response if the quantity query param is less then 1
    - the endpoint returns a 400 response if the quantity query param is a string
    - the endpoint returns a 400 response if the quantity query param is blank
    - the endpoint returns a 400 response if the quantity query param is not provided