### PR TITLE
Testing for unshiped invoice revenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,14 @@ testing
     - the endpoint returns a 400 response if the quantity query param is less then 1
     - the endpoint returns a 400 response if the quantity query param is a string
     - the endpoint returns a 400 response if the quantity query param is blank
+
+- unshipped_invoices_by_revenue
+  - Happy path testing includes:
+    - the endpoint returns 10 unshipped invoices ranked by potential revenue as the default
+    - the endpoint returns unshipped invoices equal to the quantity query params if provided
+    - the endpoint returns all of the unshipped invoices if the quantity query params are greater then the number of unshipped invoices
+  - Edge case testing includes:
+  - Sad path testing includes:
+    - - the endpoint returns a 400 response if the quantity query param is less then 1
+    - the endpoint returns a 400 response if the quantity query param is a string
+    - the endpoint returns a 400 response if the quantity query param is blank

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,8 +1,17 @@
 class Api::V1::InvoicesController < ApplicationController
 
   def unshipped_revenue
-    invoices = Invoice.unshiped_potential_revenue(params[:quantity])
+    if valid_param?(params[:quantity]) || !params[:quantity]
+      invoices = Invoice.unshiped_potential_revenue(params[:quantity])
 
-    render json: UnshippedOrderSerializer.new(invoices)
+      render json: UnshippedOrderSerializer.new(invoices)
+    else
+      render json: {error: {}}, status: :bad_request
+    end
+  end
+
+  def valid_param?(param)
+    return true if (param && param !="") && param.to_i >= 1
+    false
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,6 +10,7 @@ class Invoice < ApplicationRecord
      joins(:invoice_items)
     .where('invoices.status = ?', 'packaged')
     .select('invoices.id, sum(invoice_items.quantity * invoice_items.unit_price) as potential_revenue')
+    .order(potential_revenue: :desc)
     .group(:id)
     .limit(limit)
   end

--- a/spec/requests/unshipped_order_revenue_spec.rb
+++ b/spec/requests/unshipped_order_revenue_spec.rb
@@ -5,10 +5,73 @@ RSpec.describe "Unshiped Revenue", type: :request do
     seed_test_db
   end
 
-  it "returns the top ten unshiped invoces ranked by ravenue by default" do
-    get "/api/v1/revenue/unshipped"
+  describe "Happy Path" do
+    it "returns 10 unshipped invoices ranked by potential revenue as the default" do
+      get "/api/v1/revenue/unshipped"
 
-    expect(response.status).to eq(200)
-    expect(json[:data].count).to eq(4)
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(10)
+      expect(json[:data][0][:attributes]).to eq({:potential_revenue=>"20770.0"})
+      expect(json[:data][1][:attributes]).to eq({:potential_revenue=>"4451.0"})
+      expect(json[:data][2][:attributes]).to eq({:potential_revenue=>"2025.0"})
+      expect(json[:data][3][:attributes]).to eq({:potential_revenue=>"1891.0"})
+      expect(json[:data][4][:attributes]).to eq({:potential_revenue=>"1500.0"})
+      expect(json[:data][5][:attributes]).to eq({:potential_revenue=>"1069.75"})
+      expect(json[:data][6][:attributes]).to eq({:potential_revenue=>"1000.0"})
+      expect(json[:data][7][:attributes]).to eq({:potential_revenue=>"385.5"})
+      expect(json[:data][8][:attributes]).to eq({:potential_revenue=>"169.29"})
+      expect(json[:data][9][:attributes]).to eq({:potential_revenue=>"120.0"})
+    end
+
+    it "returns unshipped invoices equal to the quantity query params if provided" do
+      qty = 2
+      get "/api/v1/revenue/unshipped?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(2)
+      expect(json[:data][0][:attributes]).to eq({:potential_revenue=>"20770.0"})
+      expect(json[:data][1][:attributes]).to eq({:potential_revenue=>"4451.0"})
+    end
+
+    it "returns all of the unshipped invoices if the quantity query params are greater then the number of unshipped invoices" do
+      qty = 50
+      get "/api/v1/revenue/unshipped?quantity=#{qty}"
+
+      expect(response.status).to eq(200)
+      expect(json[:data].count).to eq(11)
+      expect(json[:data][0][:attributes]).to eq({:potential_revenue=>"20770.0"})
+      expect(json[:data][1][:attributes]).to eq({:potential_revenue=>"4451.0"})
+      expect(json[:data][2][:attributes]).to eq({:potential_revenue=>"2025.0"})
+      expect(json[:data][3][:attributes]).to eq({:potential_revenue=>"1891.0"})
+      expect(json[:data][4][:attributes]).to eq({:potential_revenue=>"1500.0"})
+      expect(json[:data][5][:attributes]).to eq({:potential_revenue=>"1069.75"})
+      expect(json[:data][6][:attributes]).to eq({:potential_revenue=>"1000.0"})
+      expect(json[:data][7][:attributes]).to eq({:potential_revenue=>"385.5"})
+      expect(json[:data][8][:attributes]).to eq({:potential_revenue=>"169.29"})
+      expect(json[:data][9][:attributes]).to eq({:potential_revenue=>"120.0"})
+      expect(json[:data][10][:attributes]).to eq({:potential_revenue=>"101.0"})
+    end
+  end
+
+  describe "Sad Path" do
+    it "returns a 400 response if the quantity query param is less then 1" do
+      qty = -1
+      get "/api/v1/revenue/unshipped?quantity=#{qty}"
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is a string" do
+      qty = "string"
+      get "/api/v1/revenue/unshipped?quantity=#{qty}"
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns a 400 response if the quantity query param is blank" do
+      get "/api/v1/revenue/unshipped?quantity="
+
+      expect(response.status).to eq(400)
+    end
   end
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -47,6 +47,13 @@ module RequestRailsHelper
     @invoice8 = create(:invoice, customer: @customer, merchant: @merchant6, status: "returned")
     @invoice9 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
     @invoice10 = create(:invoice, customer: @customer, merchant: @merchant10)
+    @invoice11 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice12 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice13 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice14 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice15 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice16 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
+    @invoice17 = create(:invoice, customer: @customer, merchant: @merchant10, status: "packaged")
 
     create(:transaction, invoice: @invoice1, result: "failed")
     create(:transaction, invoice: @invoice1)
@@ -78,5 +85,12 @@ module RequestRailsHelper
     create(:invoice_item, invoice: @invoice9, item: @item12, unit_price: 1, quantity: 101)
     create(:invoice_item, invoice: @invoice10, item: @item12, unit_price: 0.90, quantity: 178)
     create(:invoice_item, invoice: @invoice10, item: @item16, unit_price: 0.09, quantity: 45)
+    create(:invoice_item, invoice: @invoice11, item: @item16, unit_price: 1.50, quantity: 257)
+    create(:invoice_item, invoice: @invoice12, item: @item16, unit_price: 50.00, quantity: 20)
+    create(:invoice_item, invoice: @invoice13, item: @item16, unit_price: 45, quantity: 45)
+    create(:invoice_item, invoice: @invoice14, item: @item16, unit_price: 5, quantity: 24)
+    create(:invoice_item, invoice: @invoice15, item: @item16, unit_price: 8.91, quantity: 19)
+    create(:invoice_item, invoice: @invoice16, item: @item16, unit_price: 250, quantity: 6)
+    create(:invoice_item, invoice: @invoice17, item: @item16, unit_price: 89.02, quantity: 50)
   end
 end


### PR DESCRIPTION
- unshipped_invoices_by_revenue
  - Happy path testing includes:
    - the endpoint returns 10 unshipped invoices ranked by potential revenue as the default
    - the endpoint returns unshipped invoices equal to the quantity query params if provided
    - the endpoint returns all of the unshipped invoices if the quantity query params are greater then the number of unshipped invoices
  - Edge case testing includes:
  - Sad path testing includes:
    - - the endpoint returns a 400 response if the quantity query param is less then 1
    - the endpoint returns a 400 response if the quantity query param is a string
    - the endpoint returns a 400 response if the quantity query param is blank